### PR TITLE
Adds bucketing to checks.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stethoscope (0.2.1)
+    stethoscope (0.2.2)
       dictionary (>= 1.0)
       rack (> 1.0)
       tilt (>= 1.0)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ Returning a response _:status_ outside 200..299 will trigger Stethoscope to retu
 
 Any exceptions are caught and added to the response with the _:error_ key.  The template can then handle them appropriately
 
+Checks can be placed into buckets to target specific checks.
+
+    Stethoscope.check :database, :critical, :quick do |response|
+      ActiveRecord::Base.connection.execute("select 1")
+    end
+
+    Stethoscope.check :something_big, :critical, :expensive do |response|
+      do_something_expensive
+    end
+
+Now you have the put into buckets, you can choose which checks you want to execute. By default, all check are performed, but if you want to check only one type of check (all the checks in a given bucket) then you can just append the bucket name onto the url.
+
+#### Example
+
+    curl http://my.awesomeapp.com/heartbeat/critical.json # check the critical checks only
+    curl http://my.awesomeapp.com/heartbeat/quick.json    # check the quick checks only
+    curl http://my.awesomeapp.com/heartbeat.json          # check all the things
+
 #### Defaults
 
 * ActiveRecord

--- a/lib/stethoscope/checks/active_record.rb
+++ b/lib/stethoscope/checks/active_record.rb
@@ -1,7 +1,7 @@
 require 'stethoscope'
 
 # Provides a check for active record databases
-Stethoscope.check :database do |response|
+Stethoscope.check :database, :critical do |response|
   query = "SELECT 1"
   response["query"] = query.inspect
   ActiveRecord::Base.connection.execute(query)

--- a/lib/stethoscope/checks/data_mapper.rb
+++ b/lib/stethoscope/checks/data_mapper.rb
@@ -1,7 +1,7 @@
 require 'stethoscope'
 
 # Provides a check for datamapper databases
-Stethoscope.check :database do |response|
+Stethoscope.check :database, :critical do |response|
   query = "SELECT 1"
   response["query"] = query.inspect
   DataMapper.repository.adapter.execute(query)

--- a/lib/stethoscope/checks/mongoid2.rb
+++ b/lib/stethoscope/checks/mongoid2.rb
@@ -1,7 +1,7 @@
 require 'stethoscope'
 
 # Provides a check for mongoid databases
-Stethoscope.check :database do |response|
+Stethoscope.check :database, :critical do |response|
   collection_names = Mongoid.database.collection_names
   response["collection count"] = collection_names.size
   response["Mongoid"] = "OK"

--- a/lib/stethoscope/checks/mongoid3.rb
+++ b/lib/stethoscope/checks/mongoid3.rb
@@ -1,7 +1,7 @@
 require 'stethoscope'
 
 # Provides a check for mongoid databases
-Stethoscope.check :database do |response|
+Stethoscope.check :database, :critical do |response|
   collections = Mongoid::Sessions.default.collections
   response["collection count"] = collections.size
   response["Mongoid"] = "OK"

--- a/test/test_stethoscope.rb
+++ b/test/test_stethoscope.rb
@@ -101,6 +101,29 @@ class TestStethoscope
         response = get "/heartbeat"
         assert { response.status == 500 }
       end
+
+      test do
+        Stethoscope.check(:foo, :foo, :bar){ |response| response[:status] = 200; response[:foo] = :test1 }
+        Stethoscope.check(:bar, :bar){ |response| response[:status] = 200; response[:bar] = :test2 }
+
+        response = get "/heartbeat/foo.json"
+        results = JSON.parse(response.body)
+        assert { response.status == 200 }
+        assert { results['checks']['foo']['foo'] == 'test1' }
+        assert { !results['checks'].key?('bar') }
+
+        response = get "/heartbeat/bar.json"
+        results = JSON.parse(response.body)
+        assert { response.status == 200 }
+        assert { results['checks']['foo']['foo'] == 'test1' }
+        assert { results['checks']['bar']['bar'] == 'test2' }
+
+        response = get "/heartbeat.json"
+        results = JSON.parse(response.body)
+        assert { response.status == 200 }
+        assert { results['checks']['foo']['foo'] == 'test1' }
+        assert { results['checks']['bar']['bar'] == 'test2' }
+      end
     end
   end
 end


### PR DESCRIPTION
Adds bucketing to checks so that you can selectively run checks that may be expensive or logically grouped.

e.g.

```
Stethoscope.check :some_check, :some_bucket, :another_bucket do |r|
   #ship
end
```

Then to check only checks assigned to "some_bucket"

/heartbeat/some_bucket # check only the checks in some_bucket
/heartbeat # Check all checks
